### PR TITLE
Add ApacheHadoop Meta Barclamp [2/9]

### DIFF
--- a/crowbar.yml
+++ b/crowbar.yml
@@ -1,4 +1,4 @@
-# Copyright 2011, Dell, Inc.
+# Copyright 2012, Dell, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -22,7 +22,7 @@ barclamp:
   requires:
     - hadoop
   member:
-    - hadoop
+    - apachehadoop
 
 crowbar:
   layout: 1


### PR DESCRIPTION
This _most_ of the the impacted barclamps, I still need to update Hadoop
  and ZooKeeper on the Hadoop-os branch.

Most of the barclamps are only adding ApacheHadoop as their
parent.

The ApacheHadoop barclamp is UI only.  The old UI parts were removed
from the ClouderaManager barclamp.

 crowbar.yml |    4 ++--
 1 files changed, 2 insertions(+), 2 deletions(-)
